### PR TITLE
feat(sync_manager): update isar library to a stable version

### DIFF
--- a/packages/sync_manager/lib/src/models/cursor_sync_state.g.dart
+++ b/packages/sync_manager/lib/src/models/cursor_sync_state.g.dart
@@ -68,7 +68,7 @@ const CursorSyncStateSchema = CollectionSchema(
   getId: _cursorSyncStateGetId,
   getLinks: _cursorSyncStateGetLinks,
   attach: _cursorSyncStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _cursorSyncStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/isar_change_log_entry.g.dart
+++ b/packages/sync_manager/lib/src/models/isar_change_log_entry.g.dart
@@ -127,7 +127,7 @@ const IsarChangeLogEntrySchema = CollectionSchema(
   getId: _isarChangeLogEntryGetId,
   getLinks: _isarChangeLogEntryGetLinks,
   attach: _isarChangeLogEntryAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarChangeLogEntryEstimateSize(

--- a/packages/sync_manager/lib/src/models/isar_document_state.g.dart
+++ b/packages/sync_manager/lib/src/models/isar_document_state.g.dart
@@ -275,7 +275,7 @@ const IsarDocumentStateSchema = CollectionSchema(
   getId: _isarDocumentStateGetId,
   getLinks: _isarDocumentStateGetLinks,
   attach: _isarDocumentStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarDocumentStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/isar_entity_type_sync_state.g.dart
+++ b/packages/sync_manager/lib/src/models/isar_entity_type_sync_state.g.dart
@@ -96,7 +96,7 @@ const IsarEntityTypeSyncStateSchema = CollectionSchema(
   getId: _isarEntityTypeSyncStateGetId,
   getLinks: _isarEntityTypeSyncStateGetLinks,
   attach: _isarEntityTypeSyncStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarEntityTypeSyncStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/isar_project_state.g.dart
+++ b/packages/sync_manager/lib/src/models/isar_project_state.g.dart
@@ -280,7 +280,7 @@ const IsarProjectStateSchema = CollectionSchema(
   getId: _isarProjectStateGetId,
   getLinks: _isarProjectStateGetLinks,
   attach: _isarProjectStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarProjectStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/isar_storage_state.g.dart
+++ b/packages/sync_manager/lib/src/models/isar_storage_state.g.dart
@@ -51,7 +51,7 @@ const IsarStorageStateSchema = CollectionSchema(
   getId: _isarStorageStateGetId,
   getLinks: _isarStorageStateGetLinks,
   attach: _isarStorageStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarStorageStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/isar_task_state.g.dart
+++ b/packages/sync_manager/lib/src/models/isar_task_state.g.dart
@@ -280,7 +280,7 @@ const IsarTaskStateSchema = CollectionSchema(
   getId: _isarTaskStateGetId,
   getLinks: _isarTaskStateGetLinks,
   attach: _isarTaskStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarTaskStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/marker.entity_state.isar.g.dart
+++ b/packages/sync_manager/lib/src/models/marker.entity_state.isar.g.dart
@@ -371,7 +371,7 @@ const IsarMarkerDataEntityStateSchema = CollectionSchema(
   getId: _isarMarkerDataEntityStateGetId,
   getLinks: _isarMarkerDataEntityStateGetLinks,
   attach: _isarMarkerDataEntityStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarMarkerDataEntityStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/note.entity_state.isar.g.dart
+++ b/packages/sync_manager/lib/src/models/note.entity_state.isar.g.dart
@@ -491,7 +491,7 @@ const IsarNoteDataEntityStateSchema = CollectionSchema(
   getId: _isarNoteDataEntityStateGetId,
   getLinks: _isarNoteDataEntityStateGetLinks,
   attach: _isarNoteDataEntityStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarNoteDataEntityStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/passage_translation.entity_state.isar.g.dart
+++ b/packages/sync_manager/lib/src/models/passage_translation.entity_state.isar.g.dart
@@ -461,7 +461,7 @@ const IsarPassageDataEntityStateSchema = CollectionSchema(
   getId: _isarPassageDataEntityStateGetId,
   getLinks: _isarPassageDataEntityStateGetLinks,
   attach: _isarPassageDataEntityStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarPassageDataEntityStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/portion_translation.entity_state.isar.g.dart
+++ b/packages/sync_manager/lib/src/models/portion_translation.entity_state.isar.g.dart
@@ -311,7 +311,7 @@ const IsarPortionDataEntityStateSchema = CollectionSchema(
   getId: _isarPortionDataEntityStateGetId,
   getLinks: _isarPortionDataEntityStateGetLinks,
   attach: _isarPortionDataEntityStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarPortionDataEntityStateEstimateSize(

--- a/packages/sync_manager/lib/src/models/video_translation.entity_state.isar.g.dart
+++ b/packages/sync_manager/lib/src/models/video_translation.entity_state.isar.g.dart
@@ -371,7 +371,7 @@ const IsarVideoDataEntityStateSchema = CollectionSchema(
   getId: _isarVideoDataEntityStateGetId,
   getLinks: _isarVideoDataEntityStateGetLinks,
   attach: _isarVideoDataEntityStateAttach,
-  version: '3.3.0-dev.2',
+  version: '3.3.0',
 );
 
 int _isarVideoDataEntityStateEstimateSize(

--- a/packages/sync_manager/pubspec.yaml
+++ b/packages/sync_manager/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 resolution: workspace
 
-isar_version: &isar_version 3.3.0-dev.2
+isar_version: &isar_version ^3.3.0
 
 dependencies:
   sltt_core:
@@ -27,3 +27,4 @@ dev_dependencies:
   lints: ^3.0.0
   shelf: ^1.4.0
   shelf_router: ^1.1.4
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -333,18 +333,18 @@ packages:
     dependency: transitive
     description:
       name: isar_community
-      sha256: eae4a7e659bec0f92fc953afb8738512062df6a2ff99fe838cb53f9ed4fa6e97
+      sha256: d92315e1862448f236489c2b2b1f9a7ad5ba2405f42d87216234be4fb2e1dd2d
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0-dev.2"
+    version: "3.3.0"
   isar_community_generator:
     dependency: transitive
     description:
       name: isar_community_generator
-      sha256: "9da90eafaecf2ec482f50854373e37f3d9e33387830dbc0265bcdb74d9036e74"
+      sha256: "6ca1487b7551850f7896443aa8079a12b23cdf71a99dafb1f567c83d6e031042"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0-dev.2"
+    version: "3.3.0"
   js:
     dependency: transitive
     description:


### PR DESCRIPTION
# Upgrade Isar Community to v3.3.0 (Stable) in Sync Manager

## 🚀 Summary
Promotes the `isar_community` dependency from `3.3.0-dev.2` to `^3.3.0` (stable) within the `sync_manager` package. This update resolves a critical diamond dependency conflict with the Dart `analyzer` package, exposed by recent Flutter SDK updates.

## 🔍 Technical Details
* **Conflict Analysis:** The legacy `3.3.0-dev.2` release pins the `analyzer` package to `v7.x`. However, the current Flutter SDK (via `flutter_test`) transitively requires `analyzer v8.x+`. The Pub version solver fails because no single `analyzer` version can satisfy both constraints simultaneously.
* **Resolution:** The stable `v3.3.0` release relaxes internal constraints to support `analyzer ^8.0.0`, enabling `isar_generator` and the Flutter test infrastructure to coexist in the same build environment.
* **Impact:** This change is isolated to `sync_manager` to restore build stability and hermeticity.

